### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RafaelSolomon/dyad/security/code-scanning/1](https://github.com/RafaelSolomon/dyad/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or to the `test` job, specifying the minimum required permissions. Since the workflow only checks out code, installs dependencies, runs tests, and uploads artifacts, it does not require write access to repository contents. The minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `test` job). The best way is to add the following block after the workflow name and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed. Only the `.github/workflows/ci.yml` file needs to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
