### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/testing/fake-llm-server/package.json
+++ b/testing/fake-llm-server/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "stream": "0.0.2"
+    "stream": "0.0.2",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.18",


### PR DESCRIPTION
Potential fix for [https://github.com/RafaelSolomon/dyad/security/code-scanning/3](https://github.com/RafaelSolomon/dyad/security/code-scanning/3)

To fix the problem, we should add a rate-limiting middleware to the Express app, specifically for the routes that use `createChatCompletionHandler`, or globally if desired. The best way is to use the well-known `express-rate-limit` package, as recommended. This involves importing the package, creating a rate limiter instance (with reasonable defaults, e.g., 100 requests per 15 minutes), and applying it to the relevant routes. Since the code is in TypeScript, we should use the appropriate import syntax and types. The changes should be made in `testing/fake-llm-server/index.ts`:
- Add the import for `express-rate-limit`.
- Create a rate limiter instance.
- Apply the rate limiter to the chat completion routes (lines 186–194).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
